### PR TITLE
Use `hatchling` instead of `setuptools` to build release package

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.13" ]
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ macos-latest ]
         python-version: [ "3.13" ]
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-latest, windows-2022 ]
+        os: [ windows-latest ]
         python-version: [ "3.13" ]
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ uv pip install --upgrade batch_img
 
 ```
 ✗ batch_img --version
-0.3.7
+0.3.8
 
 
 ✗ batch_img auto ~/Documents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-build-backend = "setuptools.build_meta"
-requires = ["setuptools>=80.0"]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [project]
 name = "batch_img"
-version = "0.3.7"
+version = "0.3.8"
 description = "Batch process (resize, rotate, remove background, remove GPS, add border, set transparency, auto do all) image files (HEIC, JPG, PNG)"
 readme = "README.md"
 authors = [{ name = "John Liu", email = "rim2rim@gmail.com" }]
@@ -43,8 +43,13 @@ batch_img = "batch_img.interface:cli"
 Download = "https://pypi.org/project/batch-img/"
 Homepage = "https://github.com/john-liu2/batch_img"
 
-[tool.setuptools.packages.find]
-include = ["*"]
+[tool.hatch.build.targets.sdist]
+include = [
+    "batch_img/*.py",
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -54,7 +54,7 @@ def test_check_latest_version(mock_get_latest_pypi, data_check_latest_version):
 
 @pytest.fixture(
     params=[
-        (PKG_NAME, 0, "0.3.7"),
+        (PKG_NAME, 0, "0.3.8"),
         ("bad_bogus", 1, UNKNOWN),
     ]
 )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,7 +20,7 @@ from .helper import DotDict
 _dir = dirname(__file__)
 
 
-@pytest.fixture(params=[(PKG_NAME, "0.3.7"), ("", "0.3.8")])
+@pytest.fixture(params=[(PKG_NAME, "0.3.8"), ("", "0.3.8")])
 def ver_data(request):
     return request.param
 
@@ -36,7 +36,7 @@ def test_get_version(ver_data):
         (
             "0.9.9",
             PKG_NAME,
-            f"🔔 Update available: 0.3.7  →  0.9.9\nRun '{PKG_NAME} --update'",
+            f"🔔 Update available: 0.3.8  →  0.9.9\nRun '{PKG_NAME} --update'",
         ),
     ]
 )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,7 +20,7 @@ from .helper import DotDict
 _dir = dirname(__file__)
 
 
-@pytest.fixture(params=[(PKG_NAME, "0.3.7"), ("", "0.3.7")])
+@pytest.fixture(params=[(PKG_NAME, "0.3.7"), ("", "0.3.8")])
 def ver_data(request):
     return request.param
 
@@ -54,7 +54,7 @@ def test_check_latest_version(mock_get_latest_pypi, data_check_latest_version):
 
 @pytest.fixture(
     params=[
-        (PKG_NAME, 0, "0.3.6"),
+        (PKG_NAME, 0, "0.3.7"),
         ("bad_bogus", 1, UNKNOWN),
     ]
 )


### PR DESCRIPTION
1. Use `hatchling` instead of `setuptools` to build release package